### PR TITLE
docs: add observability framework, on-call practices, and soften staging point

### DIFF
--- a/docs/core-infrastructure.md
+++ b/docs/core-infrastructure.md
@@ -31,6 +31,20 @@ Here are the key practices and tools to establish a solid core infrastructure fo
   * **Use tracing and profiling tools:** Jaeger, Zipkin, OpenTelemetry; YourKit, VisualVM, JProfiler.
   * **Automate incident response:** PagerDuty, OpsGenie, VictorOps.
 
+**Observability:** Monitoring tells you *that* something is wrong; observability tells you *why*. A complete observability strategy rests on three signals that work together:
+
+* **Logs**: structured, timestamped records of discrete events. Essential for root-cause analysis after an incident.
+* **Metrics**: numeric measurements aggregated over time (latency, error rate, throughput). Drive dashboards, SLOs, and alerting thresholds.
+* **Traces**: end-to-end records of a request as it moves through distributed services. Pinpoint which component in a chain introduced latency or failure.
+
+Without all three, you are flying partially blind: metrics show the spike, traces show where in the call graph it happened, and logs explain what the system was doing at that moment.
+
+* **Quick Tips and Sample Tooling:**
+  * **Adopt a unified observability platform:** Datadog, Honeycomb, Grafana Stack (Loki + Tempo + Mimir).
+  * **Use OpenTelemetry for instrumentation:** vendor-neutral, covers logs, metrics, and traces in one SDK.
+  * **Define SLOs and error budgets:** tie your observability data to concrete reliability targets that the whole team can reason about.
+  * **Correlate signals:** ensure your tooling lets you jump from a metric spike → related traces → underlying logs in a single workflow.
+
 **Error Tracking and Alerting:** Identifies, prioritizes, and resolves issues quickly through real-time tracking and alerts. Provides insights into root causes, error trends, and areas for improvement.
 
 * **Quick Tips and Sample Tooling:**
@@ -55,7 +69,7 @@ Here are the key practices and tools to establish a solid core infrastructure fo
 * **Key Considerations:**
   * **Development Environments:** Should closely mirror production to reduce integration issues.
   * **On-Demand Environments (Dev-X):** Provide developers, designers, testers and QAs with easily spinnable, isolated environments for feature development and testing.
-  * **No Need For Staging:** In scenario with environment parity achieved through robust dev-x for acceptance criteria manual testing and comprehensive automated testing (including integration and regression tests), a separate staging environment becomes unnecessary. Smaller, more frequent releases tested thoroughly in production-like dev-x environments, coupled with advanced deployment strategies like canary releases or blue/green deployments, can replace traditional staging cycles which takes days/weeks.
+  * **Rethinking Staging:** In scenarios with strong environment parity (robust dev-x environments for acceptance testing and comprehensive automated coverage including integration and regression tests), a long-lived staging environment often adds overhead without adding safety. Smaller, more frequent releases tested in production-like dev-x environments, paired with deployment strategies like canary releases or blue/green deployments, can replace traditional staging cycles that take days or weeks. **However**, this trade-off does not apply universally. Regulated industries (finance, healthcare), complex data migration scenarios, or systems with strict partner sign-off requirements may still warrant a dedicated pre-production stage. The goal is intentional environment design: not eliminating staging as a rule, but ensuring every environment in your pipeline earns its place.
   * **Partner Integration Environments:** Dedicated environments for partners to integrate and test their systems with yours.
   * **Tooling:** Docker, Kubernetes, Terraform, Vagrant, CloudFormation.
 
@@ -90,3 +104,13 @@ Here are the key practices and tools to establish a solid core infrastructure fo
   * **Conduct disaster recovery drills:** Simulate incidents and test recovery plans with the SRE team.
   * **Automate recovery procedures:** AWS CloudFormation, Terraform, Ansible.
   * **Monitor recovery metrics and performance:** RTO, RPO, MTTR.
+
+**On-Call Practices and Incident Response:** Tooling like PagerDuty routes alerts, but the process around it determines whether incidents are resolved quickly or cause prolonged outages. A well-defined on-call culture is as important as the monitoring infrastructure itself.
+
+* **Key Considerations:**
+  * **Runbooks:** For every critical alert, maintain a runbook: a short, step-by-step document that describes what the alert means, how to investigate it, and the standard remediation steps. Runbooks reduce cognitive load at 3 a.m. and accelerate handoffs between engineers.
+  * **On-call rotations:** Distribute on-call duty fairly across the team to avoid burnout. Rotations should be predictable, documented, and supported by clear handoff notes at each transition.
+  * **Escalation paths:** Define who gets paged first, who to escalate to if unresolved, and when to involve leadership or external vendors. Ambiguity in escalation leads to delayed decisions during critical incidents.
+  * **Incident severity levels:** Agree on a shared severity classification (e.g., P1–P4) so teams know what response time and communication cadence each level requires.
+  * **Post-incident reviews:** After every significant incident, conduct a blameless review to capture the timeline, contributing factors, and action items. This closes the loop back to the culture of continuous improvement described in Pillar 1.
+  * **Tooling:** Grafana Alerting, PagerDuty, OpsGenie, Incident.io, FireHydrant.


### PR DESCRIPTION
This pull request enhances the core infrastructure documentation by expanding guidance on observability, environment design, and incident response. The updates provide deeper context on best practices, clarify when to use certain environments, and introduce actionable recommendations for on-call operations.

Expanded observability guidance:

* Added a new section explaining the difference between monitoring and observability, emphasizing the importance of logs, metrics, and traces as complementary signals. Included practical tips and tooling recommendations such as unified observability platforms and OpenTelemetry for instrumentation.

Environment design clarification:

* Revised the discussion on staging environments to clarify that while robust development environments and modern deployment strategies can reduce the need for a traditional staging environment, certain scenarios (regulated industries, complex migrations, partner sign-off) may still require one. Stresses intentional environment design over rigid rules.

Incident response and on-call practices:

* Added a new section outlining best practices for on-call rotations, runbooks, escalation paths, incident severity levels, and post-incident reviews. Emphasizes the cultural and procedural aspects of incident handling alongside tooling